### PR TITLE
Add dockerfile with builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV FORCE_UNSAFE_CONFIGURE 1
+
+RUN apt-get update && \
+    apt-get install -y \
+    pkg-config libudev-dev \
+    build-essential make ncurses-dev  g++ gcc git gzip \
+    bash bc binutils build-essential bzip2 cpio \
+    locales libncurses5-dev libdevmapper-dev libsystemd-dev make \
+    mercurial whois patch perl python rsync sed \
+    tar vim unzip wget bison flex libssl-dev libfdt-dev
+
+RUN git clone https://github.com/furkantokac/buildroot
+
+WORKDIR /buildroot
+
+ENTRYPOINT /bin/bash


### PR DESCRIPTION
As this project is already a bit outdated, and there are some dependency issues when you try to create image with gcc>9 for example. I thought that defining a docker image capable of building the os image and compiling the qt stuff might be beneficial.